### PR TITLE
Add custom warning message functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ Private Eye supports CommonJS, and is thus compatible with [Browserify](http://b
     var PrivateEye = require('private-eye');
     ```
 
-## Usage
+## Basic Usage
+
+To get started using Private Eye, initialize `PrivateEye` with an object
+containing an `ignoreUrls` property with a list of URLs to match.
 
 ```javascript
 document.addEventListener('DOMContentLoaded', function() {
@@ -52,6 +55,97 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 }, false );
 ```
+
+## Advanced Usage
+
+Private Eye supports custom messages for links.
+The examples below provide different ways to customize a URL's messaging from
+general to granular.
+
+### Reconfiguring the default message
+
+The default message given to links can be configured across all private urls by
+passing in an option named `defaultMessage`. This property is added to the
+object passed into `PrivateEye( { /*...*/ } );`.
+
+```javascript
+document.addEventListener('DOMContentLoaded', function() {
+  PrivateEye({
+    // Update the default message to a custom `string`.
+    defaultMessage: "This link is secured, please ensure you have the proper credentials to access it."
+    ignoreUrls: [
+      'http://so.me/private/url',
+      'anoth.er',
+      // ...
+    ]
+  });
+}, false );
+```
+
+In the example above, all URLs matched by `ignoreURLs` will have the customized
+`defaultMessage` as the message the user sees when they hover over the link.
+
+### Configuring custom messages for individual URLs
+
+Custom messaging is supported on a per-URL basis as well. This is done by
+passing an object in the `ignoreUrls` array with a `url` and `message` property
+for the URL to match and the message to display respectively.
+
+```javascript
+document.addEventListener('DOMContentLoaded', function() {
+  PrivateEye({
+    ignoreUrls: [
+      'http://so.me/private/url',
+      // Custom messages for individual URLs are passed in as an object.
+      {
+        url: 'anoth.er',
+        message: 'This is another link that may not be accessible to you without the proper credentials',
+      },
+      // ...
+    ]
+  });
+}, false );
+```
+
+In the example above, the URL matches for `http://so.me/private/url` will have
+the base default message. The URL matches for `anoth.er` will have a specific
+custom message for _only_ those individual matches.
+
+### Using HTML to configure granular individual custom messages.
+
+Custom messaging is supported on a per-element basis. If a `title` attribute is
+found on any matched `anchor`, the default or custom messaging is never set on
+the `anchor`.  The original `title` attribute is left unmodified. This can be
+used to customize individual `anchor` elements on a more granular level.
+
+```javascript
+// Set up for the plugin is the same as "Basic Usage" above.
+document.addEventListener('DOMContentLoaded', function() {
+  PrivateEye({
+    // list of URLs to match as substrings – can be full URLs, hostnames, etc.
+    ignoreUrls: [
+      'http://so.me/private/url',
+      'anoth.er',
+      // ...
+    ]
+  });
+}, false );
+```
+
+```html
+<!-- Base, or configured, default messaging for this link. -->
+<a href="http://so.me/private/url">A private URL</a>
+<!-- Granluar custom message for only this specific element. -->
+<a href="http://so.me/private/url" title="This link is still private and you may not have access to it.">Another private URL</a>
+```
+
+In the example above, the customized message is set as a `title` attribute on
+one of the matched `anchor` elements. The first match without a `title`
+attribute will have the base default message. The second match with a `title`
+attribute will have the custom message found in `title`. This use case is
+particularly useful if you HTML page already contains valuable messaging around
+private URLs, or if you'd like to configure the messaging without the need of
+using JavaScript.
 
 ## See also
 

--- a/private-eye.js
+++ b/private-eye.js
@@ -6,14 +6,11 @@
     styles.innerHTML = 'a.private-link::after { content: "\\1F512"; font-size: 0.75em; vertical-align: top; }';
     document.body.appendChild(styles);
 
-    var DEFAULT_MESSAGE = "This is a link to a private site, which may or may not be accessible to you.";
-    var hrefValue;
-    var linkMessage;
-
     opts.ignoreUrls.forEach(function(url) {
 
-      hrefValue = url;
-      linkMessage = DEFAULT_MESSAGE;
+      var DEFAULT_MESSAGE = "This is a link to a private site, which may or may not be accessible to you.";
+      var hrefValue;
+      var linkMessage;
 
       // If the `url` is an Object, then parse the properties `message` & `url`
       //
@@ -21,6 +18,11 @@
 
         linkMessage = url.message;
         hrefValue = url.url;
+
+      } else {
+
+        hrefValue = url;
+        linkMessage = DEFAULT_MESSAGE;
 
       }
 

--- a/private-eye.js
+++ b/private-eye.js
@@ -6,23 +6,33 @@
     styles.innerHTML = 'a.private-link::after { content: "\\1F512"; font-size: 0.75em; vertical-align: top; }';
     document.body.appendChild(styles);
 
+    var defaultMessage;
+
+    if ( opts.defaultMessage && 'string' === typeof opts.defaultMessage ) {
+
+      defaultMessage = opts.defaultMessage;
+
+    } else {
+
+      defaultMessage = "This is a link to a private site, which may or may not be accessible to you.";
+    }
+
     opts.ignoreUrls.forEach(function(url) {
 
-      var DEFAULT_MESSAGE = "This is a link to a private site, which may or may not be accessible to you.";
       var hrefValue;
-      var linkMessage;
+      var titleValue;
 
       // If the `url` is an Object, then parse the properties `message` & `url`
       //
       if ( url === Object( url ) ) {
 
-        linkMessage = url.message;
+        titleValue = url.message;
         hrefValue = url.url;
 
       } else {
 
         hrefValue = url;
-        linkMessage = DEFAULT_MESSAGE;
+        titleValue = defaultMessage;
 
       }
 
@@ -34,7 +44,7 @@
         //
         if ( ! anchor.title ) {
 
-          anchor.title = linkMessage;
+          anchor.title = titleValue;
 
         }
 

--- a/private-eye.js
+++ b/private-eye.js
@@ -32,7 +32,7 @@
 
         // Only replace the anchor's title if it is empty
         //
-        if ( '' === anchor.title ) {
+        if ( ! anchor.title ) {
 
           anchor.title = linkMessage;
 

--- a/private-eye.js
+++ b/private-eye.js
@@ -6,11 +6,36 @@
     styles.innerHTML = 'a.private-link::after { content: "\\1F512"; font-size: 0.75em; vertical-align: top; }';
     document.body.appendChild(styles);
 
+    var DEFAULT_MESSAGE = "This is a link to a private site, which may or may not be accessible to you.";
+    var hrefValue;
+    var linkMessage;
+
     opts.ignoreUrls.forEach(function(url) {
-      var anchors = document.querySelectorAll('a[href*="' + url + '"]');
+
+      hrefValue = url;
+      linkMessage = DEFAULT_MESSAGE;
+
+      // If the `url` is an Object, then parse the properties `message` & `url`
+      //
+      if ( url === Object( url ) ) {
+
+        linkMessage = url.message;
+        hrefValue = url.url;
+
+      }
+
+      var anchors = document.querySelectorAll('a[href*="' + hrefValue + '"]');
       Array.prototype.forEach.call(anchors, function(anchor) {
         anchor.className += ' private-link';
-        anchor.title = "This is a link to a private site, which may or may not be accessible to you.";
+
+        // Only replace the anchor's title if it is empty
+        //
+        if ( '' === anchor.title ) {
+
+          anchor.title = linkMessage;
+
+        }
+
       });
     });
   };


### PR DESCRIPTION
This patch adds the custom warning functionality in two different ways:
- [x] Passing a configuration object to match the URL and attach a custom message.
- [x] Leaving the title attribute untouched if there is already one.
