### PR TITLE
add link to github repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
       <div class="usa-width-one-whole">
         <img src="assets/img/detective.png">
         <h1>Private Eye</h1>
+        <p>Made by <a href="https://18f.gsa.gov">18F</a>.  Available on <a href="https://github.com/18F/private-eye/">GitHub</a>.</p>
         <p>A JavaScript plugin to warn users about links to private pages. Places a :lock: icon next to any links with any URLs that you specify as private, and gives a warning message.</p>
         <p>At 18F, this is used on public sites that contain links to internal content like private GitHub repositories or Google Docs. Rather than write two versions to redact those links, this allows us to publish new content and give a warning to both staff and external readers.</p>
         <p>Use <code>ignoreUrls</code> to supply all the private URLs. Any link that matches one of the URLs will have a lock icon next to it.</p>


### PR DESCRIPTION
Trying this again - this adds a link to Github repo on the demo website as requested in #15.
