### PR TITLE
Add defer attribute to example script tag in README.md and demo site.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Compatible with modern browsers (IE 9+). No dependencies.
 Private Eye can be included as a normal script on your page, exposing a `PrivateEye` global.
 
 ```html
-<script src="private-eye.js"></script>
+<script src="private-eye.js" defer></script>
 ```
 
 ### CommonJS

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@ document.addEventListener('DOMContentLoaded', function() {
         </pre></code>
       </div>
     </div>
-    <script src="private-eye.js"></script>
+    <script src="private-eye.js" defer></script>
     <script>
     document.addEventListener('DOMContentLoaded', function() {
       PrivateEye({


### PR DESCRIPTION
DOMContentLoaded should fire after deferred scripts are loaded, so I believe this is all the changes that need to be made. Fixes #10 
