### PR TITLE
Expand "Developing" section on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,4 +173,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
 ## Developing
 
-This project uses `jest` for testing. Tests can be run with `npm test` or `npm test:watch` to rerun tests when files change.
+To get started developing, simply clone this repo and you're ready. Private Eye has no dependencies and does not have a build process. All code for Private Eye is located in `private-eye.js`.
+
+This project uses `jest` for testing. First, run `npm install` which will install jest. Tests can be run with `npm test` or `npm test:watch` to rerun tests when files change.


### PR DESCRIPTION
Right now, the "Developing" section of the README doesn't have instructions on how to start developing. There isn't really actually any steps necessary, but it's worth noting that explicitly. It's also good to note you have to run `npm install` before running the test suite.